### PR TITLE
fix: add "ubuntu" to docker host file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
     hostname: ubuntu
     container_name: pwnable-kr-docker
     network_mode: "host"
+    extra_hosts:
+      - "ubuntu:127.0.0.1"
     ports:
       - "2159"
     cap_add:


### PR DESCRIPTION
The sudo utility breaks down if it doesn't manage to resolve this name.